### PR TITLE
Changed XML header encoding to ISO-8859-1.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,7 @@ Fixed
 ^^^^^
 * Fixed #11. Error in docstring.
 * Fixed #10. additional_info on AlarmRequest as dict did not convert to string.
+* Fixed #12. Encoding error when sending to some alarm receives.
 
 Security
 ^^^^^^^^

--- a/sos_access/schemas.py
+++ b/sos_access/schemas.py
@@ -271,8 +271,8 @@ class SOSAccessSchema(marshmallow.Schema):
     def load_xml(self, data, **kwargs):
         try:
             # incoming XML
-            print(data)
             parsed_data = xmltodict.parse(data)
+
             # remove envelope
             in_data = parsed_data[self.__envelope__]
         except xml.parsers.expat.ExpatError as e:
@@ -285,7 +285,10 @@ class SOSAccessSchema(marshmallow.Schema):
         data_to_dump = {self.__envelope__: data}
         # make xml
         try:
-            out_data = xmltodict.unparse(data_to_dump)
+            # the encoding is the same as latin-1 but if we specify latin-1 the xml
+            # header will say latin-1 too. to be compliant with SOS Alarm we use the
+            # text that their alarm server outputs.
+            out_data = xmltodict.unparse(data_to_dump, encoding="iso-8859-1")
         except xml.parsers.expat.ExpatError as e:
             raise XMLParseError from e
         return out_data


### PR DESCRIPTION
Some alarmservers threw an error since we hade set the XML encoding to UTF-8 and sent the data as latin-1 (iso-8859-1).
I should be iso-8859-1 so changed the default behaviour. Tested against SOS Alarm and worked both ways.
Fixes #12